### PR TITLE
Update uuid-to-address.js

### DIFF
--- a/lib/mac/uuid-to-address.js
+++ b/lib/mac/uuid-to-address.js
@@ -16,7 +16,7 @@ module.exports = function(uuid, callback) {
                         uuid.substring(16, 20) + '-' +
                         uuid.substring(20);
 
-    var coreBluetoothCacheEntry = obj[0].CoreBluetoothCache[formattedUuid];
+    var coreBluetoothCacheEntry = obj[0].CoreBluetoothCache ? obj[0].CoreBluetoothCache[formattedUuid] : undefined;
     var address = coreBluetoothCacheEntry ? coreBluetoothCacheEntry.DeviceAddress.replace(/-/g, ':') : undefined;
 
     callback(null, address);


### PR DESCRIPTION
this minor change seems to have fixed a case on my mac where CoreBluetoothCache was not a defined member of obj[0].
